### PR TITLE
Remove deprecated `react-tools` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A react component to display Pokemon",
   "main": "pokemon.js",
   "dependencies": {
-    "react-tools": "~0.8.0"
+    "react": "^15.2.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/pokemon.js
+++ b/pokemon.js
@@ -6,7 +6,7 @@
     });
   } else if (typeof exports === 'object') {
     // Node, sorta CommonJS
-    module.exports = factory(require('react-tools').React);
+    module.exports = factory(require('react'));
   } else {
     // Browser global
     root.Pokemon = factory(root.React);


### PR DESCRIPTION
`react-tools` has been [deprecated](https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html). Demo works for me locally :)
